### PR TITLE
Hey there.  I've suggested an improvement to your nginx location block and fixed a "bug"

### DIFF
--- a/core/css.php
+++ b/core/css.php
@@ -41,7 +41,7 @@ class CSS extends \Kirby\Component\CSS {
       $cssInput = (new Asset($url))->content();
       $cssIntegrity = sri_checksum($cssInput);
 
-      if(settings::fingerprinting()) {
+      if(\settings::fingerprinting()) {
         // add timestamp for cache-busting
         $modified = filemtime($url);
         $filename = f::name($url) . '.' . $modified . '.' . f::extension($url);
@@ -52,7 +52,7 @@ class CSS extends \Kirby\Component\CSS {
       // build an array of SRI-related attributes
       $cssOptions = array(
         'integrity' => $cssIntegrity, // generated SRI hash
-        'crossorigin' => settings::crossorigin(), // user-defined 'crossorigin' attribute
+        'crossorigin' => \settings::crossorigin(), // user-defined 'crossorigin' attribute
       );
     }
 

--- a/core/js.php
+++ b/core/js.php
@@ -40,7 +40,7 @@ class JS extends \Kirby\Component\JS {
       $jsInput = (new Asset($src))->content();
       $jsIntegrity = sri_checksum($jsInput);
 
-      if(settings::fingerprinting()) {
+      if(\settings::fingerprinting()) {
         // add timestamp for cache-busting
         $modified = filemtime($src);
         $filename = f::name($src) . '.' . $modified . '.' . f::extension($src);
@@ -51,7 +51,7 @@ class JS extends \Kirby\Component\JS {
       // build an array of SRI-related attributes
       $jsOptions = array(
         'integrity' => $jsIntegrity, // generated SRI hash
-        'crossorigin' => settings::crossorigin(), // user-defined 'crossorigin' attribute
+        'crossorigin' => \settings::crossorigin(), // user-defined 'crossorigin' attribute
       );
     }
 


### PR DESCRIPTION
My nginx location block is 'better' because it avoids the dreaded [nginx if statement](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/).

Secondly, a bug in the plugin surfaced because if the js or css file referenced doesn't exist the $cssIntegrity/$jsIntegrity variable wasn't getting defined.   I simply set the variable to a default value that indicates that the file couldn't be found.   I'm not sure if that's the better solution or if it's better to set it to null or '' or what.

Anyway, thanks for the plugin.