### PR TITLE
Fix error Class 'S1SYPHOS\SRI\settings' not found in PHP 7.0.2

### DIFF
--- a/core/css.php
+++ b/core/css.php
@@ -41,7 +41,7 @@ class CSS extends \Kirby\Component\CSS {
       $cssInput = (new Asset($url))->content();
       $cssIntegrity = sri_checksum($cssInput);
 
-      if(settings::fingerprinting()) {
+      if(\settings::fingerprinting()) {
         // add timestamp for cache-busting
         $modified = filemtime($url);
         $filename = f::name($url) . '.' . $modified . '.' . f::extension($url);
@@ -52,7 +52,7 @@ class CSS extends \Kirby\Component\CSS {
       // build an array of SRI-related attributes
       $cssOptions = array(
         'integrity' => $cssIntegrity, // generated SRI hash
-        'crossorigin' => settings::crossorigin(), // user-defined 'crossorigin' attribute
+        'crossorigin' => \settings::crossorigin(), // user-defined 'crossorigin' attribute
       );
     }
 

--- a/core/js.php
+++ b/core/js.php
@@ -40,7 +40,7 @@ class JS extends \Kirby\Component\JS {
       $jsInput = (new Asset($src))->content();
       $jsIntegrity = sri_checksum($jsInput);
 
-      if(settings::fingerprinting()) {
+      if(\settings::fingerprinting()) {
         // add timestamp for cache-busting
         $modified = filemtime($src);
         $filename = f::name($src) . '.' . $modified . '.' . f::extension($src);
@@ -51,7 +51,7 @@ class JS extends \Kirby\Component\JS {
       // build an array of SRI-related attributes
       $jsOptions = array(
         'integrity' => $jsIntegrity, // generated SRI hash
-        'crossorigin' => settings::crossorigin(), // user-defined 'crossorigin' attribute
+        'crossorigin' => \settings::crossorigin(), // user-defined 'crossorigin' attribute
       );
     }
 


### PR DESCRIPTION
Hey there.. I'm back..

So I installed the new version today and I'm getting an error:

<img width="1776" alt="screenshot 2017-11-22 18 04 22" src="https://user-images.githubusercontent.com/3205232/33140224-a5d1ff8e-cfaf-11e7-98c4-dd95b1c16f1c.png">

My patches here fix the error, but I'm not sure if it's the cleanest fix. 